### PR TITLE
Add root-level test script and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,5 +25,14 @@ You can find synthetic data ready for ingestion in `data/`:
 - `pilot_logbook_populated_120.csv`
 - `pilot_logbook_populated_120.xlsx`
 
+## Running Tests
+Once the project scripts are set up, run tests from the repository root:
+
+```bash
+npm test
+```
+
+This command delegates to the test script defined in `app/package.json`.
+
 ## License
 MIT

--- a/app/package.json
+++ b/app/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
+    "test": "node --test",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "SaaS_logAvia",
+  "private": true,
+  "scripts": {
+    "test": "npm --prefix app test"
+  }
+}


### PR DESCRIPTION
## Summary
- Add root `package.json` with private flag and test script delegating to app tests
- Enable Node's built-in test runner in `app/package.json`
- Document running tests from project root

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf6401c22c83318662bd3ea06e5d2b