### PR TITLE
test: cover excel loader and time utils

### DIFF
--- a/app/src/lib/loadExcel.test.js
+++ b/app/src/lib/loadExcel.test.js
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from 'vitest';
+import ExcelJS from 'exceljs';
+
+vi.mock('exceljs/dist/exceljs.min.js', async () => {
+  const Excel = await import('exceljs');
+  return { default: Excel };
+});
+
+import { loadLogbook } from './loadExcel.js';
+
+describe('loadLogbook', () => {
+  it('parses rows into objects keyed by headers', async () => {
+    const workbook = new ExcelJS.Workbook();
+    const ws = workbook.addWorksheet('Sheet1');
+    ws.addRow(['Name', 'Age']);
+    ws.addRow(['Alice', 30]);
+    ws.addRow([null, null]);
+    ws.addRow(['Bob', '']);
+    const buf = await workbook.xlsx.writeBuffer();
+
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      arrayBuffer: () => Promise.resolve(buf),
+    });
+
+    const rows = await loadLogbook('test.xlsx');
+
+    expect(fetch).toHaveBeenCalledWith('test.xlsx');
+    expect(rows).toEqual([
+      { Name: 'Alice', Age: '30' },
+      { Name: 'Bob', Age: '' },
+    ]);
+  });
+
+  it('throws when fetch response is not ok', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 404 });
+    await expect(loadLogbook('missing.xlsx')).rejects.toThrow('Failed to fetch missing.xlsx: 404');
+  });
+});

--- a/app/src/lib/time.js
+++ b/app/src/lib/time.js
@@ -1,0 +1,17 @@
+export function toMinutes(hhmm) {
+  if (hhmm == null || hhmm === '') return 0;
+  const s = String(hhmm).trim();
+  if (s.includes(':')) {
+    const [h, m] = s.split(':');
+    return (Number(h) || 0) * 60 + (Number(m) || 0);
+  }
+  const num = Number(s);
+  return Number.isNaN(num) ? 0 : num;
+}
+
+export function toHHMM(mins) {
+  const total = Number(mins) || 0;
+  const h = Math.floor(total / 60);
+  const m = Math.round(total % 60);
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+}

--- a/app/src/lib/time.test.js
+++ b/app/src/lib/time.test.js
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { toMinutes, toHHMM } from './time.js';
+
+describe('time utilities', () => {
+  describe('toMinutes', () => {
+    it('converts HH:MM strings to minutes', () => {
+      expect(toMinutes('02:30')).toBe(150);
+      expect(toMinutes('2:5')).toBe(125);
+    });
+
+    it('handles plain minute values and invalid input', () => {
+      expect(toMinutes('90')).toBe(90);
+      expect(toMinutes(null)).toBe(0);
+      expect(toMinutes('abc')).toBe(0);
+    });
+  });
+
+  describe('toHHMM', () => {
+    it('formats minutes into HH:MM', () => {
+      expect(toHHMM(0)).toBe('00:00');
+      expect(toHHMM(125)).toBe('02:05');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for Excel logbook parser including fetch error handling
- add shared time utility with conversions and unit tests

## Testing
- `npm --prefix app test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68c65375bae48331a039b5c43e6824a8