### PR TITLE
feat: add shared time utilities

### DIFF
--- a/app/scripts/compute_pic_minutes.js
+++ b/app/scripts/compute_pic_minutes.js
@@ -4,21 +4,10 @@
 import fs from 'fs';
 import path from 'path';
 import ExcelJS from 'exceljs';
+import { toMinutes } from '../src/utils/time.js';
 
 const APP_ROOT = path.resolve('c:\\Users\\rafae\\SaaS_logAvia\\app');
 const PUBLIC_DATA = path.join(APP_ROOT, 'public', 'data');
-
-function toMinutes(hhmm) {
-  if (hhmm == null) return 0;
-  const s = String(hhmm).trim();
-  if (s === '') return 0;
-  if (s.includes(':')) {
-    const [h, m] = s.split(':');
-    return (parseInt(h, 10) || 0) * 60 + (parseInt(m, 10) || 0);
-  }
-  const n = Number(s.replace(/[^0-9.-]/g, ''));
-  return Number.isFinite(n) ? n : 0;
-}
 
 async function loadSheetMinutes(filePath) {
   const wb = new ExcelJS.Workbook();

--- a/app/scripts/detect_and_test_pilots_from_general.js
+++ b/app/scripts/detect_and_test_pilots_from_general.js
@@ -1,21 +1,10 @@
 // Detect pilots from logbook.xlsx and test PIC minutes per pilot by scanning the general logbook file
 import ExcelJS from 'exceljs';
 import path from 'path';
+import { toMinutes } from '../src/utils/time.js';
 
 const APP_ROOT = path.resolve('c:\\Users\\rafae\\SaaS_logAvia\\app');
 const DATA_FILE = path.join(APP_ROOT, 'public', 'data', 'logbook.xlsx');
-
-function toMinutes(hhmm) {
-  if (hhmm == null) return 0;
-  const s = String(hhmm).trim();
-  if (s === '') return 0;
-  if (s.includes(':')) {
-    const [h, m] = s.split(':');
-    return (parseInt(h, 10) || 0) * 60 + (parseInt(m, 10) || 0);
-  }
-  const n = Number(s.replace(/[^0-9.-]/g, ''));
-  return Number.isFinite(n) ? n : 0;
-}
 
 async function loadLogbookWorkbook(filePath){
   const wb = new ExcelJS.Workbook();

--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -1,18 +1,7 @@
 import React, { useEffect, useState } from "react";
 import PilotLogbookDashboard from "./components/PilotLogbookDashboard.jsx";
 import { loadLogbook } from "@/lib/loadExcel.js";
-
-// helpers to convert "HH:MM"
-function toMinutes(hhmm) {
-  if (!hhmm) return 0;
-  const [h, m] = String(hhmm).split(":");
-  return (parseInt(h || 0, 10) * 60) + (parseInt(m || 0, 10));
-}
-function toHHMM(mins) {
-  const h = String(Math.floor(mins / 60)).padStart(2, "0");
-  const m = String(mins % 60).padStart(2, "0");
-  return `${h}:${m}`;
-}
+import { toMinutes, toHHMM } from "@/utils/time.js";
 
 // Read a cell value using a list of possible header variants.
 function getCell(row, variants) {

--- a/app/src/components/PilotLogbookDashboard.jsx
+++ b/app/src/components/PilotLogbookDashboard.jsx
@@ -4,20 +4,9 @@ import { MapPin, Clock, Plane } from 'lucide-react';
 import { loadLogbook } from '@/lib/loadExcel.js';
 import StatCard from './StatCard.jsx';
 import Card from './Card.jsx';
+import { toMinutes } from '@/utils/time.js';
 
 const COLORS = ['#0088FE', '#00C49F', '#FFBB28', '#FF8042', '#8884D8'];
-
-function toMinutes(hhmm) {
-  if (hhmm == null) return 0;
-  const s = String(hhmm).trim();
-  if (s === '') return 0;
-  if (s.includes(':')) {
-    const [h, m] = s.split(':');
-    return (parseInt(h, 10) || 0) * 60 + (parseInt(m, 10) || 0);
-  }
-  const n = Number(s.replace(/[^0-9.-]/g, ''));
-  return Number.isFinite(n) ? n : 0;
-}
 
 // Format date-like values to a simple local date (strip time and timezone like "20:00:00 GMT-0400 (Chile Standard Time)")
 function formatDate(value) {

--- a/app/src/utils/time.js
+++ b/app/src/utils/time.js
@@ -1,0 +1,20 @@
+export function toMinutes(hhmm) {
+  if (hhmm == null) return 0;
+  const s = String(hhmm).trim();
+  if (s === '') return 0;
+  if (s.includes(':')) {
+    const [h, m] = s.split(':');
+    return (parseInt(h, 10) || 0) * 60 + (parseInt(m, 10) || 0);
+  }
+  const n = Number(s.replace(/[^0-9.-]/g, ''));
+  return Number.isFinite(n) ? n : 0;
+}
+
+export function toHHMM(mins) {
+  if (!Number.isFinite(mins)) return '00:00';
+  const sign = mins < 0 ? '-' : '';
+  const abs = Math.abs(Math.round(mins));
+  const h = String(Math.floor(abs / 60)).padStart(2, '0');
+  const m = String(abs % 60).padStart(2, '0');
+  return `${sign}${h}:${m}`;
+}

--- a/app/src/utils/time.test.js
+++ b/app/src/utils/time.test.js
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { toMinutes, toHHMM } from './time.js';
+
+describe('toMinutes', () => {
+  it('converts HH:MM strings', () => {
+    expect(toMinutes('02:30')).toBe(150);
+    expect(toMinutes('1:2')).toBe(62);
+    expect(toMinutes(':45')).toBe(45);
+  });
+
+  it('handles numbers and numeric strings', () => {
+    expect(toMinutes(90)).toBe(90);
+    expect(toMinutes('90')).toBe(90);
+  });
+
+  it('returns 0 for blank or invalid input', () => {
+    expect(toMinutes('')).toBe(0);
+    expect(toMinutes(null)).toBe(0);
+    expect(toMinutes(undefined)).toBe(0);
+    expect(toMinutes('abc')).toBe(0);
+  });
+
+  it('strips non-numeric characters', () => {
+    expect(toMinutes('1h30m')).toBe(130);
+  });
+});
+
+describe('toHHMM', () => {
+  it('formats minutes to HH:MM', () => {
+    expect(toHHMM(0)).toBe('00:00');
+    expect(toHHMM(5)).toBe('00:05');
+    expect(toHHMM(65)).toBe('01:05');
+    expect(toHHMM(150)).toBe('02:30');
+  });
+
+  it('rounds and preserves sign', () => {
+    expect(toHHMM(90.7)).toBe('01:31');
+    expect(toHHMM(-90.4)).toBe('-01:30');
+  });
+
+  it('returns 00:00 for invalid numbers', () => {
+    expect(toHHMM(Number.NaN)).toBe('00:00');
+  });
+});


### PR DESCRIPTION
## Summary
- add `toMinutes` and `toHHMM` helpers in `utils/time.js`
- replace local time conversion helpers with shared utilities
- test time utility edge cases

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c65371c9a0833195d48c9afdf023a0