### PR TITLE
Simplify PIC column lookup

### DIFF
--- a/app/scripts/compute_pic_minutes.js
+++ b/app/scripts/compute_pic_minutes.js
@@ -28,8 +28,7 @@ async function loadSheetMinutes(filePath) {
     // skip empty rows
     if (vals.every(v => v == null || String(v).trim() === '')) continue;
     // determine PIC column by header name containing 'PIC'
-    const findIndex = headers.findIndex(h => h && h.toUpperCase().includes('PIC'));
-    const picIndex = findIndex;
+    const picIndex = headers.findIndex(h => h && h.toUpperCase().includes('PIC'));
     if (picIndex < 0) continue; // no PIC column
     const v = vals[picIndex];
     totals += toMinutes(v);


### PR DESCRIPTION
## Summary
- inline the PIC column lookup rather than storing in an intermediate variable

## Testing
- node app/scripts/compute_pic_minutes.js

------
https://chatgpt.com/codex/tasks/task_e_68c86a633338833181ec6e0bbdc981f2