### PR TITLE
Gate debug logging behind opt-in flag

### DIFF
--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import PilotLogbookDashboard from "./components/PilotLogbookDashboard.jsx";
 import { loadLogbook } from "@/lib/loadExcel.js";
 import { toMinutes, toHHMM } from "@/utils/time.js";
+import { debugLog } from "@/utils/debug.js";
 
 // Read a cell value using a list of possible header variants.
 function getCell(row, variants) {
@@ -100,14 +101,10 @@ export default function App() {
     )[0];
   }, [filteredRows]);
 
-  // Debug: log rows, filteredRows, and lastFlight after all are computed
-  console.log("rows", rows);
-  console.log("filteredRows", filteredRows);
-  console.log("lastFlight", lastFlight);
-
-  // Debug: log filteredRows and lastFlight after initialization
-  console.log("filteredRows", filteredRows);
-  console.log("lastFlight (App)", lastFlight);
+  // Optional debug output: enable via VITE_LOGBOOK_DEBUG=true or localStorage.setItem('logbookDebug', 'true')
+  debugLog("rows", rows);
+  debugLog("filteredRows", filteredRows);
+  debugLog("lastFlight", lastFlight);
 
   return (
     <div style={{ padding: 16 }}>

--- a/app/src/components/PilotLogbookDashboard.jsx
+++ b/app/src/components/PilotLogbookDashboard.jsx
@@ -5,6 +5,7 @@ import { loadLogbook } from '@/lib/loadExcel.js';
 import StatCard from './StatCard.jsx';
 import Card from './Card.jsx';
 import { toMinutes } from '@/utils/time.js';
+import { debugLog } from '@/utils/debug.js';
 
 const COLORS = ['#0088FE', '#00C49F', '#FFBB28', '#FF8042', '#8884D8'];
 
@@ -103,9 +104,10 @@ export default function PilotLogbookDashboard({ pilotInfo = null, summary = unde
     return () => { mounted = false; };
   }, [pilotInfo]);
 
-  console.log("Grid wrapper applied");
-  console.log("lastFlight", lastFlight);
-  console.log('PilotLogbookDashboard lastFlight prop:', lastFlight);
+  // Optional debug output mirrors App: set VITE_LOGBOOK_DEBUG=true or toggle localStorage.
+  debugLog('Grid wrapper applied');
+  debugLog('lastFlight', lastFlight);
+  debugLog('PilotLogbookDashboard lastFlight prop:', lastFlight);
 
   // Custom tooltip to show per-slice minutes instead of relying on default payload rendering
   function CustomTooltip({ active, payload }) {

--- a/app/src/components/StatCard.test.jsx
+++ b/app/src/components/StatCard.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
 import StatCard from './StatCard';
 
 describe('StatCard', () => {

--- a/app/src/lib/loadExcel.test.js
+++ b/app/src/lib/loadExcel.test.js
@@ -18,7 +18,7 @@ describe('loadLogbook', () => {
     ws.addRow(['Bob', '']);
     const buf = await workbook.xlsx.writeBuffer();
 
-    global.fetch = vi.fn().mockResolvedValue({
+    globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
       arrayBuffer: () => Promise.resolve(buf),
     });
@@ -33,7 +33,7 @@ describe('loadLogbook', () => {
   });
 
   it('throws when fetch response is not ok', async () => {
-    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 404 });
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: false, status: 404 });
     await expect(loadLogbook('missing.xlsx')).rejects.toThrow('Failed to fetch missing.xlsx: 404');
   });
 });

--- a/app/src/utils/debug.js
+++ b/app/src/utils/debug.js
@@ -1,0 +1,23 @@
+const isDebugEnabled = () => {
+  if (import.meta.env?.VITE_LOGBOOK_DEBUG === "true") return true;
+  if (typeof window !== "undefined") {
+    try {
+      return window.localStorage?.getItem("logbookDebug") === "true";
+    } catch {
+      // Access to localStorage can fail in privacy modes; treat as disabled.
+      return false;
+    }
+  }
+  return false;
+};
+
+export function debugLog(...args) {
+  if (isDebugEnabled()) {
+    console.log(...args);
+  }
+}
+
+// Enable verbose logging in the browser console with one of the following:
+//   1. Use an environment flag when running Vite: VITE_LOGBOOK_DEBUG=true npm run dev
+//   2. Persist a toggle in devtools: localStorage.setItem('logbookDebug', 'true')
+// Remove the flag or call localStorage.removeItem('logbookDebug') to silence logs.


### PR DESCRIPTION
## Summary
- replace inline console logging in App and PilotLogbookDashboard with a shared debugLog helper
- document how to re-enable logging through an environment flag or localStorage toggle
- update test files for Vitest globals to keep the lint run clean

## Testing
- npm --prefix app run lint

------
https://chatgpt.com/codex/tasks/task_e_68c86a4de8ec833187d5d6b572888655